### PR TITLE
Keep data generation logs off stdout

### DIFF
--- a/scripts/generate-data.ts
+++ b/scripts/generate-data.ts
@@ -67,8 +67,8 @@ const data: GoogleIpsData = { countries, ips, byCountry };
 fs.mkdirSync(path.dirname(outputPath), { recursive: true });
 fs.writeFileSync(outputPath, `${JSON.stringify(data, null, 2)}\n`);
 
-console.log(`Generated ${outputPath}`);
-console.log(`${ips.length} IPs across ${countries.length} countries`);
+console.error(`Generated ${outputPath}`);
+console.error(`${ips.length} IPs across ${countries.length} countries`);
 
 function assertIpv4(ip: string): void {
   const octets = ip.split(".").map(Number);


### PR DESCRIPTION
## Summary
- send data generation progress messages to stderr instead of stdout
- keep npm pack --json stdout machine-readable when prepack runs the generator

## Verification
- npm run typecheck
- npm test
- npm pack --json | ConvertFrom-Json
- npm pack --dry-run