### PR TITLE
Test package export resolution

### DIFF
--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { createRequire } from "node:module";
 import test from "node:test";
 import {
   byCountry,
@@ -9,6 +10,8 @@ import {
   ips,
   random,
 } from "../src";
+
+const requirePackage = createRequire(__filename);
 
 test("exports the generated IP list", () => {
   assert.equal(ips.length, 4312);
@@ -62,4 +65,13 @@ test("validates country input", () => {
   assert.throws(() => {
     getByCountry(123 as unknown as string);
   }, TypeError);
+});
+
+test("resolves package exports", () => {
+  const googleIps = requirePackage("google-ips") as typeof import("../src");
+  const data = requirePackage("google-ips/data") as typeof import("../data/google-ips.json");
+
+  assert.equal(googleIps.ips.length, 4312);
+  assert.equal(data.ips.length, googleIps.ips.length);
+  assert.equal(googleIps.findCountry("118.174.25.251"), "Thailand");
 });


### PR DESCRIPTION
## Summary
- add coverage for package self-reference resolution
- verify both the main export and google-ips/data subpath load through package.json exports

## Verification
- npm run typecheck
- npm test
- npm pack --dry-run